### PR TITLE
Version bump to 0.1.6

### DIFF
--- a/cantopy/xenocanto_components/recording.py
+++ b/cantopy/xenocanto_components/recording.py
@@ -1,8 +1,6 @@
-from datetime import timedelta, datetime
 from typing import Dict
 
 import pandas as pd
-from pandas import Timestamp
 
 
 class Recording:
@@ -11,7 +9,7 @@ class Recording:
 
     Attributes
     ----------
-    recording_id : int
+    recording_id : str
         The recording id number of the recording on xeno-canto.
     generic_name : str
         Generic name of the species.
@@ -29,9 +27,9 @@ class Recording:
         Country where the recording was made.
     locality_name : str
         Name of the locality.
-    latitude : float
+    latitude : str
         Latitude of the recording in decimal coordinates.
-    longitude : float
+    longitude : str
         Longitude of the recording in decimal coordinates.
     sound_type : str
         Sound type of the recording (combining both predefined terms such as 'call' or 'song'
@@ -50,11 +48,11 @@ class Recording:
         URL describing the license of this recording.
     quality_rating : str
         Current quality rating for the recording.
-    recording_length : timedelta
+    recording_length : str
         Length of the recording in a timedelta.
-    recording_timestamp : datetime
+    recording_timestamp : str
         Timestamp that the recording was made.
-    upload_timestamp : datetime
+    upload_date : str
         Date that the recording was uploaded to xeno-canto.
     background_species : list
         An array with the identified background species in the recording.
@@ -66,14 +64,13 @@ class Recording:
         Was playback used to lure the animal?
     temperature : str
         Temperature during recording (applicable to specific groups only).
-
     automatic_recording : str
         Automatic (non-supervised) recording?
     recording_device : str
         Recording device used.
     microphone_used : str
         Microphone used.
-    sample_rate : int
+    sample_rate : str
         Sample rate.
 
     Notes
@@ -95,37 +92,9 @@ class Recording:
         recording_data : Dict[str, str]
             The dict of the recording returned by the XenoCanto API
         """
-        # Extract the recording length from the given string representation
-        length_in_minutes = recording_data.get("length", "").split(":")
-        recording_length = timedelta(
-            minutes=int(length_in_minutes[0]), seconds=int(length_in_minutes[1])
-        )
-
-        # Extract the full timestamp from the given string representation
-        recording_date = recording_data.get("date", "")
-        recording_time = recording_data.get("time", "")
-
-        # In some cases, a date is returned with the day value set to 0 (e.g. "2020-08-00")
-        # In this case, set the day value to 1
-        if recording_date.endswith("-00"):
-            recording_date = recording_date[:-2] + "01"
-
-        # Create a Timestamp object from the date and time
-        recording_timestamp = (
-            Timestamp(f"{recording_date}T{recording_time}")
-            if not (recording_time == "?" or recording_time == "")  # If time is not set
-            else Timestamp(recording_date)
-        )
-
-        # Extract the uploaded timestamp
-        uploaded_timestamp = datetime.fromisoformat(recording_data.get("uploaded", ""))
-
-        ####################################################################
-        # Set the Recording object attributes
-        ####################################################################
 
         # Id
-        self.recording_id = int(recording_data.get("id", 0))
+        self.recording_id = recording_data.get("id", 0)
 
         # Animal information
         self.generic_name = recording_data.get("gen", "")
@@ -144,10 +113,11 @@ class Recording:
         self.recording_method = recording_data.get("method", "")
         self.license_url = recording_data.get("lic", "")
         self.quality_rating = recording_data.get("q", "")
-        self.recording_length = recording_length
-        self.recording_timestamp = recording_timestamp
+        self.recording_length = recording_data.get("length", "")
+        self.recording_date = recording_data.get("date", "")
+        self.recording_time = recording_data.get("time", "")
         self.date = recording_data.get("date", "")
-        self.upload_timestamp = uploaded_timestamp
+        self.upload_date = recording_data.get("uploaded", "")
         self.recording_url = recording_data.get("url", "")
         self.audio_file_url = recording_data.get("file", "")
         self.recordist_remarks = recording_data.get("rmk", "")
@@ -155,23 +125,12 @@ class Recording:
         self.automatic_recording = recording_data.get("auto", "")
         self.recording_device = recording_data.get("dvc", "")
         self.microphone_used = recording_data.get("mic", "")
-        self.sample_rate = (
-            int(recording_data.get("smp", 0)) if recording_data.get("smp", 0) else 0
-        )
-
+        self.sample_rate = recording_data.get("smp", 0)
         # Location information
         self.country = recording_data.get("cnt", "")
         self.locality_name = recording_data.get("loc", "")
-        self.latitude = (
-            float(recording_data.get("lat", ""))
-            if recording_data.get("lat", "")
-            else None
-        )
-        self.longitude = (
-            float(recording_data.get("lng", ""))
-            if recording_data.get("lng", "")
-            else None
-        )
+        self.latitude = recording_data.get("lat", "")
+        self.longitude = recording_data.get("lng", "")
         self.temperature = recording_data.get("temp", "")
 
     def to_dataframe_row(self) -> pd.DataFrame:
@@ -200,9 +159,10 @@ class Recording:
             "license_url": [self.license_url],
             "quality_rating": [self.quality_rating],
             "recording_length": [self.recording_length],
-            "recording_timestamp": [self.recording_timestamp],
+            "recording_date": [self.recording_date],
+            "recording_time": [self.recording_time],
             "date": [self.date],
-            "upload_timestamp": [self.upload_timestamp],
+            "upload_date": [self.upload_date],
             "recording_url": [self.recording_url],
             "audio_file_url": [self.audio_file_url],
             "recordist_remarks": [self.recordist_remarks],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cantopy"
-version = "0.1.5"
+version = "0.1.6"
 description = "A XenoCanto API wrapper for Python"
 authors = ["RobbeRDG <robbedegroeve@gmail.com>"]
 license = "MIT"

--- a/tests/download/test_downloadmanager.py
+++ b/tests/download/test_downloadmanager.py
@@ -238,35 +238,35 @@ def test_downloadmanager_generate_downloaeded_recording_metadata(
     if example_queryresult_fixture_name == "example_single_page_queryresult":
         assert len(downloaded_recording_metadata) == 2
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 581412  # type: ignore
+            downloaded_recording_metadata["recording_id"] == "581412"  # type: ignore
         ].equals(example_queryresult.result_pages[0].recordings[0].to_dataframe_row())
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 581411
+            downloaded_recording_metadata["recording_id"] == "581411"
         ].empty
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 427716  # type: ignore
+            downloaded_recording_metadata["recording_id"] == "427716"  # type: ignore
         ].equals(
             example_queryresult.result_pages[0].recordings[2].to_dataframe_row()  # type: ignore
         )
     elif example_queryresult_fixture_name == "example_two_page_queryresult":
         assert len(downloaded_recording_metadata) == 4
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 581412  # type: ignore
+            downloaded_recording_metadata["recording_id"] == "581412"  # type: ignore
         ].equals(example_queryresult.result_pages[0].recordings[0].to_dataframe_row())
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 581411
+            downloaded_recording_metadata["recording_id"] == "581411"
         ].empty
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 427716  # type: ignore
+            downloaded_recording_metadata["recording_id"] == "427716"  # type: ignore
         ].equals(example_queryresult.result_pages[0].recordings[2].to_dataframe_row())
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 220366
+            downloaded_recording_metadata["recording_id"] == "220366"
         ].empty
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 220365  # type: ignore
+            downloaded_recording_metadata["recording_id"] == "220365"  # type: ignore
         ].equals(example_queryresult.result_pages[1].recordings[1].to_dataframe_row())
         assert downloaded_recording_metadata.loc[
-            downloaded_recording_metadata["recording_id"] == 196385  # type: ignore
+            downloaded_recording_metadata["recording_id"] == "196385"  # type: ignore
         ].equals(example_queryresult.result_pages[1].recordings[2].to_dataframe_row())
 
 

--- a/tests/xenocanto_components/test_recording.py
+++ b/tests/xenocanto_components/test_recording.py
@@ -16,7 +16,7 @@ def test_recording_init(
     # See if all recording fields are captured
     assert (
         example_recording_1_from_example_xenocanto_query_response_page_1.recording_id
-        == 581412
+        == "581412"
     )
     assert (
         example_recording_1_from_example_xenocanto_query_response_page_1.generic_name
@@ -52,11 +52,11 @@ def test_recording_init(
     )
     assert (
         example_recording_1_from_example_xenocanto_query_response_page_1.latitude
-        == -15.3915
+        == "-15.3915"
     )
     assert (
         example_recording_1_from_example_xenocanto_query_response_page_1.longitude
-        == -39.5643
+        == "-39.5643"
     )
     assert (
         example_recording_1_from_example_xenocanto_query_response_page_1.sound_type
@@ -91,19 +91,19 @@ def test_recording_init(
         == "A"
     )
     assert (
-        example_recording_1_from_example_xenocanto_query_response_page_1.recording_length.seconds
-        == 194
+        example_recording_1_from_example_xenocanto_query_response_page_1.recording_length
+        == "3:14"
     )
     assert (
-        example_recording_1_from_example_xenocanto_query_response_page_1.recording_timestamp.strftime(
-            "%Y-%m-%d %X"
-        )
-        == "2020-08-02 08:00:00"
+        example_recording_1_from_example_xenocanto_query_response_page_1.recording_date
+        == "2020-08-02"
     )
     assert (
-        example_recording_1_from_example_xenocanto_query_response_page_1.upload_timestamp.strftime(
-            "%Y-%m-%d"
-        )
+        example_recording_1_from_example_xenocanto_query_response_page_1.recording_time
+        == "08:00"
+    )
+    assert (
+        example_recording_1_from_example_xenocanto_query_response_page_1.upload_date
         == "2020-08-09"
     )
     assert (
@@ -136,7 +136,7 @@ def test_recording_init(
     )
     assert (
         example_recording_1_from_example_xenocanto_query_response_page_1.sample_rate
-        == 48000
+        == "48000"
     )
 
 
@@ -158,7 +158,7 @@ def test_to_dataframe_row(
     )
 
     # test if the dataframe row contains the correct information
-    assert example_recording_df_row["recording_id"][0] == 581412
+    assert example_recording_df_row["recording_id"][0] == "581412"
     assert example_recording_df_row["generic_name"][0] == "Odontophorus"
     assert example_recording_df_row["specific_name"][0] == "capueira"
     assert example_recording_df_row["subspecies_name"][0] == "plumbeicollis"
@@ -170,8 +170,8 @@ def test_to_dataframe_row(
         example_recording_df_row["locality_name"][0]
         == "RPPN Serra Bonita, Camacan-BA, Bahia"
     )
-    assert example_recording_df_row["latitude"][0] == -15.3915
-    assert example_recording_df_row["longitude"][0] == -39.5643
+    assert example_recording_df_row["latitude"][0] == "-15.3915"
+    assert example_recording_df_row["longitude"][0] == "-39.5643"
     assert example_recording_df_row["sound_type"][0] == "duet, song"
     assert example_recording_df_row["sex"][0] == "female, male"
     assert example_recording_df_row["life_stage"][0] == "adult"
@@ -186,9 +186,10 @@ def test_to_dataframe_row(
         == "//creativecommons.org/licenses/by-nc-sa/4.0/"
     )
     assert example_recording_df_row["quality_rating"][0] == "A"
-    assert example_recording_df_row["recording_length"][0].seconds == 194  # type: ignore
-    assert example_recording_df_row["recording_timestamp"][0].strftime("%Y-%m-%d %X") == "2020-08-02 08:00:00"  # type: ignore
-    assert example_recording_df_row["upload_timestamp"][0].strftime("%Y-%m-%d") == "2020-08-09"  # type: ignore
+    assert example_recording_df_row["recording_length"][0] == "3:14"
+    assert example_recording_df_row["recording_time"][0] == "08:00"
+    assert example_recording_df_row["recording_date"][0] == "2020-08-02"
+    assert example_recording_df_row["upload_date"][0] == "2020-08-09"
     assert example_recording_df_row["background_species"][0] == ["Sclerurus scansor"]
     assert example_recording_df_row["recordist_remarks"][0] == ""
     assert example_recording_df_row["animal_seen"][0] == "yes"
@@ -196,20 +197,5 @@ def test_to_dataframe_row(
     assert example_recording_df_row["automatic_recording"][0] == "no"
     assert example_recording_df_row["recording_device"][0] == ""
     assert example_recording_df_row["microphone_used"][0] == ""
-    assert example_recording_df_row["sample_rate"][0] == 48000
+    assert example_recording_df_row["sample_rate"][0] == "48000"
 
-
-def test_zero_day_date_recording(example_zero_day_xenocanto_recording: Recording):
-    """Test if the day of a date of a recording is set to zero when given a recording
-    containing a date where the day part is set to 0.
-
-    Parameters
-    ----------
-    example_zero_day_xenocanto_recording : Recording
-        A Recording object based on a XenoCanto API query response where the recording date is set to 2003-03-00.
-    """
-
-    # Check if the recording date is set to the current date
-    assert example_zero_day_xenocanto_recording.recording_timestamp.year == 2003
-    assert example_zero_day_xenocanto_recording.recording_timestamp.month == 3
-    assert example_zero_day_xenocanto_recording.recording_timestamp.day == 1

--- a/tests/xenocanto_components/test_resultpage.py
+++ b/tests/xenocanto_components/test_resultpage.py
@@ -15,4 +15,4 @@ def test_resultpage_init(example_result_page_page_1: ResultPage):
     # Just check if recording is also set,
     # but more detailed recording evaluation is in the Recording test section
     assert len(example_result_page_page_1.recordings) == 3
-    assert example_result_page_page_1.recordings[0].recording_id == 581412
+    assert example_result_page_page_1.recordings[0].recording_id == "581412"


### PR DESCRIPTION
- Removed all the initial data processing steps when initializing a Recording object from the returned recording JSON response of the XenoCanto API (e.g. creating timestamp from date and time fields, casting id to integer, ...). These steps are removed in order to reduce the need for lot of processing edge case handling caused by some weird values returned by the XenoCanto API (e.g. dates with "00" fields like "2003-03-00")