### PR TITLE
0.2.3 version

### DIFF
--- a/cantopy/download_manager.py
+++ b/cantopy/download_manager.py
@@ -166,7 +166,11 @@ class DownloadManager:
         """
 
         # Get the list of animals
-        animals = downloaded_recordings_metadata["english_name"].unique()  # type: ignore
+        animals = (
+            downloaded_recordings_metadata["english_name"].unique()
+            if len(downloaded_recordings_metadata) > 0
+            else []
+        )
 
         # For each animal, update its metadata file
         for animal in animals:

--- a/cantopy/fetch_manager.py
+++ b/cantopy/fetch_manager.py
@@ -82,7 +82,7 @@ class FetchManager:
         query_response = requests.get(
             cls._base_url,
             params=payload_str,
-            timeout=5.0,
+            timeout=30.0,
         ).json()
 
         # Extract the metadata information of this query

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cantopy"
-version = "0.2.2"
+version = "0.2.3"
 description = "A XenoCanto API wrapper for Python"
 authors = ["RobbeRDG <robbedegroeve@gmail.com>"]
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from cantopy.xenocanto_components import QueryResult, Recording, ResultPage
 from cantopy import DownloadManager
 
 
-
 ######################################################################
 #### CONSTANTS
 ######################################################################
@@ -25,6 +24,7 @@ TEST_DATA_BASE_FOLDER_PATH = (
 ######################################################################
 #### XENOCANTO COMPONENT FIXTURES
 ######################################################################
+
 
 @pytest.fixture(scope="session")
 def example_fake_xenocanto_recording() -> Recording:
@@ -120,7 +120,7 @@ def example_query_metadata_page_1(
 
     Parameters
     ----------
-    example_xenocanto_query_response_page_1 : Dict[str, str | int | List[Dict[str, str]]]
+    example_xenocanto_query_response_page_1
         The dictionary representation of example XenoCanto API query response.
 
     Returns
@@ -164,7 +164,7 @@ def example_query_metadata_page_2(
 
     Parameters
     ----------
-    example_xenocanto_query_response_page_2 : Dict[str, str | int | List[Dict[str, str]]]
+    example_xenocanto_query_response_page_2
         The dictionary representation of example page 2 XenoCanto API query response.
 
     Returns
@@ -207,7 +207,7 @@ def example_result_page_page_1(
 
     Parameters
     ----------
-    example_xenocanto_query_response_page_1 : Dict[str, str | int | List[Dict[str, str]]]
+    example_xenocanto_query_response_page_1
         The dictionary representation of example page 1 XenoCanto API query response.
 
     Returns
@@ -226,7 +226,7 @@ def example_result_page_page_2(
 
     Parameters
     ----------
-    example_xenocanto_query_response_page_2 : Dict[str, str | int | List[Dict[str, str]]]
+    example_xenocanto_query_response_page_2
         The dictionary representation of example page 2 XenoCanto API query response.
 
     Returns
@@ -246,7 +246,7 @@ def example_recording_1_from_example_xenocanto_query_response_page_1(
 
     Parameters
     ----------
-    example_xenocanto_query_response_page_1 : Dict[str, str | int | List[Dict[str, str]]]
+    example_xenocanto_query_response_page_1
         The dictionary representation of example page 1 XenoCanto API query response.
 
     Returns
@@ -275,9 +275,9 @@ def example_single_page_queryresult(
 
     Parameters
     ----------
-    example_query_metadata_page_1 : Dict[str, str | int | List[Dict[str, str]]]
+    example_query_metadata_page_1
         The extracted metadata from the example page 1 XenoCanto API query response.
-    example_result_page : ResultPage
+    example_result_page
         The ResultPage object created from the example page 1 XenoCanto API query response
 
     Returns
@@ -300,12 +300,12 @@ def example_two_page_queryresult(
 
     Parameters
     ----------
-    example_query_metadata_page_1 : Dict[str, int]
+    example_query_metadata_page_1
         The extracted metadata from the example page 1 XenoCanto API query response.
         Page 2 metadata is the same as page 1 metadata, so this is not needed.
-    example_result_page_page_1 : ResultPage
+    example_result_page_page_1
         The ResultPage object created from the example page 1 XenoCanto API query response.
-    example_result_page_page_2 : ResultPage
+    example_result_page_page_2
         The ResultPage object created from the example page 2 XenoCanto API query response.
 
     Returns
@@ -368,10 +368,10 @@ def partially_filled_download_data_base_path(
 
     Parameters
     ----------
-    spot_winged_wood_quail_partial_test_recording_metadata : pd.DataFrame
+    spot_winged_wood_quail_partial_test_recording_metadata
         The test recording metadata for the spot-winged wood quail recordings that are already
         present.
-    little_nightjar_partial_test_recording_metadata : pd.DataFrame
+    little_nightjar_partial_test_recording_metadata
         The test recording metadata for the little nightjar recordings that are already
         present.
 
@@ -424,7 +424,7 @@ def empty_data_folder_download_manager(empty_download_data_base_path: str):
 
     Parameters
     ----------
-    empty_download_data_base_path : str
+    empty_download_data_base_path
         The path to a newly created empty download folder.
 
     Returns
@@ -443,7 +443,7 @@ def partially_filled_data_folder_download_manager(
 
     Parameters
     ----------
-    partially_filled_download_data_base_path : str
+    partially_filled_download_data_base_path
         The path to a newly created but partially-filled data folder.
 
     Returns
@@ -515,9 +515,9 @@ def combined_full_test_recording_metadata(
 
     Parameters
     ----------
-    little_nightjar_full_test_recording_metadata : pd.DataFrame
+    little_nightjar_full_test_recording_metadata
         The loaded full test recording metadata for the little nightjar.
-    spot_winged_wood_quail_full_test_recording_metadata : pd.DataFrame
+    spot_winged_wood_quail_full_test_recording_metadata
         The loaded full test recording metadata for the spot-winged wood quail.
 
     Returns
@@ -582,9 +582,9 @@ def combined_partial_test_recording_metadata(
 
     Parameters
     ----------
-    little_nightjar_partial_test_recording_metadata : pd.DataFrame
+    little_nightjar_partial_test_recording_metadata
         The loaded partial test recording metadata for the little nightjar.
-    spot_winged_wood_quail_partial_test_recording_metadata : pd.DataFrame
+    spot_winged_wood_quail_partial_test_recording_metadata
         The loaded partial test recording metadata for the spot-winged wood quail.
 
     Returns
@@ -649,9 +649,9 @@ def combined_to_add_test_recording_metadata(
 
     Parameters
     ----------
-    little_nightjar_to_add_test_recording_metadata : pd.DataFrame
+    little_nightjar_to_add_test_recording_metadata
         The loaded test recording metadata for the little nightjar we want to add.
-    spot_winged_wood_quail_to_add_test_recording_metadata : pd.DataFrame
+    spot_winged_wood_quail_to_add_test_recording_metadata
         The loaded test recording metadata for the spot-winged wood quail we want to add.
 
     Returns

--- a/tests/test_downloadmanager.py
+++ b/tests/test_downloadmanager.py
@@ -27,16 +27,16 @@ def test_downloadmanager_download_recordings(
 
     Parameters
     ----------
-    empty_data_folder_download_manager : DownloadManager
+    empty_data_folder_download_manager
         DownloadManager instance set to an empty data folder.
-    example_queryresult_fixture_name : str
+    example_queryresult_fixture_name
         Fixture name of the example QueryResult object based on the example XenoCanto API responses.
-    add_fake_recording : bool
+    add_fake_recording
         Whether to add a fake recording to the recordings to download in order to test fail
         scenarios.
-    example_fake_xenocanto_recording : Recording
+    example_fake_xenocanto_recording
         Example fake recording to add to the recordings to download in order to test fail
-    request : pytest.FixtureRequest
+    request
         Request fixture to get the example QueryResult object.
     """
     example_queryresult: QueryResult = request.getfixturevalue(
@@ -151,11 +151,11 @@ def test_downloadmanager_detect_already_donwloaded_recordings(
 
     Parameters
     ----------
-    example_queryresult_fixture_name : str
+    example_queryresult_fixture_name
         Fixture name of the example QueryResult object based on the example XenoCanto API response.
-    partially_filled_data_folder_download_manager : DownloadManager
+    partially_filled_data_folder_download_manager
         DownloadManager instance set to a partially-filled data folder.
-    request : pytest.FixtureRequest
+    request
         Request fixture to get the example QueryResult object.
     """
     example_queryresult: QueryResult = request.getfixturevalue(
@@ -271,24 +271,24 @@ def test_downloadmanager_update_animal_recordings_metadata_files(
 
     Parameters
     ----------
-    partially_filled_data_folder_download_manager : DownloadManager
+    partially_filled_data_folder_download_manager
         DownloadManager instance set to a partially-filled data folder.
-    metadata_to_add_fixture_name : str
+    metadata_to_add_fixture_name
         Fixture name of the metadata to add to the recording metadata files that are
         already present in the data folder of the DownloadManager instance.
-    request : pytest.FixtureRequest
+    request
         Request fixture to get the metadata to add to the recording metadata files.
-    spot_winged_wood_quail_partial_test_recording_metadata : pd.DataFrame
+    spot_winged_wood_quail_partial_test_recording_metadata
         Partial test recording metadata for the spot-winged wood quail that is already
         present in the data folder of the DownloadManager instance.
-    spot_winged_wood_quail_full_test_recording_metadata : pd.DataFrame
+    spot_winged_wood_quail_full_test_recording_metadata
         Full test recording metadata for the spot-winged wood quail that should be
         the result of an update operation that adds to the spot-winged wood quail
         metadata.
-    little_nightjar_partial_test_recording_metadata : pd.DataFrame
+    little_nightjar_partial_test_recording_metadata
         Partial test recording metadata for the little nightjar that is already
         present in the data folder of the DownloadManager instance.
-    little_nightjar_full_test_recording_metadata : pd.DataFrame
+    little_nightjar_full_test_recording_metadata
         Full test recording metadata for the little nightjar that should be
         the result of an update operation that adds to the little nightjar
         metadata.
@@ -379,12 +379,12 @@ def test_downloadmanager_update_animal_recordings_metadata_files_for_empty_updat
 
     Parameters
     ----------
-    partially_filled_data_folder_download_manager : DownloadManager
+    partially_filled_data_folder_download_manager
         DownloadManager instance set to a partially-filled data folder.
-    spot_winged_wood_quail_partial_test_recording_metadata : pd.DataFrame
+    spot_winged_wood_quail_partial_test_recording_metadata
         Partial test recording metadata for the spot-winged wood quail that is already
         present in the data folder of the DownloadManager instance.
-    little_nightjar_partial_test_recording_metadata : pd.DataFrame
+    little_nightjar_partial_test_recording_metadata
         Partial test recording metadata for the little nightjar that is already
         present in the data folder of the DownloadManager instance.
 
@@ -423,7 +423,7 @@ def test_downloadmanager_generate_animal_folder_name(
 
     Parameters
     ----------
-    fake_data_folder_download_manager : DownloadManager
+    fake_data_folder_download_manager
         DownloadManager instance set to a non-existant path, since we won't be downloading anything.
     """
     # Spaces should be replaced by "_"

--- a/tests/test_fetchmanager.py
+++ b/tests/test_fetchmanager.py
@@ -52,9 +52,9 @@ def test_query_multipage(fetch_manager: FetchManager, query: Query):
 
     Parameters
     ----------
-    fetch_manager : FetchManager
+    fetch_manager
         An instance of the FetchManager class.
-    query : Query
+    query
         The Query object to send to the XenoCanto API.
     """
 

--- a/tests/xenocanto_components/test_query.py
+++ b/tests/xenocanto_components/test_query.py
@@ -25,7 +25,7 @@ def test_to_string(query_for_tostring_test: Query):
 
     Parameters
     ----------
-    query_for_tostring_test : Query
+    query_for_tostring_test
         The Query object to test the to_string method on.
     """
     assert (

--- a/tests/xenocanto_components/test_queryresult.py
+++ b/tests/xenocanto_components/test_queryresult.py
@@ -1,6 +1,7 @@
 from cantopy.xenocanto_components import ResultPage, QueryResult
 import pytest
 
+
 @pytest.mark.parametrize(
     "example_queryresult_fixture_name, expected_num_pages",
     [
@@ -19,15 +20,15 @@ def test_query_result_initialization(
 
     Parameters
     ----------
-    example_queryresult_fixture_name : str
+    example_queryresult_fixture_name
         Fixture name of the example QueryResult object based on the example XenoCanto API response.
-    expected_num_pages : int
+    expected_num_pages
         Expected number of ResultPage instances in the QueryResult object.
-    example_result_page_page_1 : ResultPage
+    example_result_page_page_1
         Example ResultPage object based on the example page 2 XenoCanto API response.
-    example_result_page_page_2 : ResultPage
+    example_result_page_page_2
         Example ResultPage object based on the example page 2 XenoCanto API response.
-    request : pytest.FixtureRequest
+    request
         Request fixture to get the example QueryResult object.
     """
     example_queryresult: QueryResult = request.getfixturevalue(
@@ -65,13 +66,13 @@ def test_query_result_get_all_recordings(
 
     Parameters
     ----------
-    example_queryresult_fixture_name : str
+    example_queryresult_fixture_name
         Fixture name of the example QueryResult object based on the example XenoCanto API response.
-    example_result_page_page_1 : ResultPage
+    example_result_page_page_1
         Example ResultPage object based on the example page 1 XenoCanto API response.
-    example_result_page_page_2 : ResultPage
+    example_result_page_page_2
         Example ResultPage object based on the example page 2 XenoCanto API response.
-    request : pytest.FixtureRequest
+    request
         Request fixture to get the example QueryResult object.
     """
 

--- a/tests/xenocanto_components/test_recording.py
+++ b/tests/xenocanto_components/test_recording.py
@@ -8,7 +8,7 @@ def test_recording_init(
 
     Parameters
     ----------
-    example_recording_1_from_example_xenocanto_query_response_page_1 : Recording
+    example_recording_1_from_example_xenocanto_query_response_page_1
         A Recording object based on the first recording in the example page 1 XenoCanto
         API query response.
     """
@@ -147,7 +147,7 @@ def test_to_dataframe_row(
 
     Parameters
     ----------
-    example_recording_1_from_example_xenocanto_query_response_page_1 : Recording
+    example_recording_1_from_example_xenocanto_query_response_page_1
         A Recording object based on the first recording in the example page 1 XenoCanto
         API query response.
     """
@@ -198,4 +198,3 @@ def test_to_dataframe_row(
     assert example_recording_df_row["recording_device"][0] == ""
     assert example_recording_df_row["microphone_used"][0] == ""
     assert example_recording_df_row["sample_rate"][0] == "48000"
-

--- a/tests/xenocanto_components/test_resultpage.py
+++ b/tests/xenocanto_components/test_resultpage.py
@@ -1,11 +1,12 @@
 from cantopy.xenocanto_components import ResultPage
 
+
 def test_resultpage_init(example_result_page_page_1: ResultPage):
     """Test for the initialisation of a ResultPage object.
 
     Parameters
     ----------
-    example_result_page_page_1 : ResultPage
+    example_result_page_page_1
         The ResultPage object created from the example page 1 XenoCanto API query response
     """
 


### PR DESCRIPTION
Fix main bug of DownloadManager not being able to handle empty metadata updates (e.g. when all downloads have failed)